### PR TITLE
fix: handle spaces in bluetooth name

### DIFF
--- a/injector/adapter.py
+++ b/injector/adapter.py
@@ -28,7 +28,7 @@ class Adapter:
 
   def set_name(self, name):
     if self.adapter.Name != name:
-      run(["sudo", "hciconfig", self.iface, "name", name])
+      run(["sudo", "hciconfig", self.iface, "name", f"\"{name}\""])
       if name not in run(["hciconfig", self.iface, "name"]).decode():
         log.error("Unable to set adapter name, aborting.")
         sys.exit(1)


### PR DESCRIPTION
Like the name says.
```
> sudo hciconfig hci0 name Hi, My Name is Keyboard
Warning: unknown command - "My"
Warning: unknown command - "Name"
Warning: unknown command - "is"
Warning: unknown command - "Keyboard"

> sudo hciconfig hci0 name "Hi, My Name is Keyboard"
```

Tested the attack against my Google Pixel 3a XL. Works like a charm. Very scary...
I tested using the latest Kali. Kali did complain about the spaces.
