### PR TITLE
Added missing dependency to README.md clean setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo apt-get -y upgrade
 # install dependencies from apt
 sudo apt install -y bluez-tools bluez-hcidump libbluetooth-dev \
                     git gcc python3-pip python3-setuptools \
-                    python3-pydbus
+                    python3-pydbus python3-dbus
 
 # install pybluez from source
 git clone https://github.com/pybluez/pybluez.git

--- a/injector/hid.py
+++ b/injector/hid.py
@@ -199,6 +199,8 @@ def ascii_to_hid(c):
     return (Key.Equal, Key.LeftShift, Mod.LeftShift)
   elif c in ['\r', '\n']:
     return (Key.Enter,)
+  elif c == '_':
+    return (Key.Minus, Mod.LeftShift)
   else:
     log.error("UNKNOWN '%s'" % c)
 


### PR DESCRIPTION
When running this POC on a fresh system, I got the error `ModuleNotFoundError: No module named 'dbus'`, installing `python3-dbus` resolves it.

Updated the README.md to include this dependency.